### PR TITLE
removing tmp_df from copy_from_stringio

### DIFF
--- a/notebooks/Psycopg2_Bulk_Insert_Speed_Benchmark.ipynb
+++ b/notebooks/Psycopg2_Bulk_Insert_Speed_Benchmark.ipynb
@@ -909,7 +909,6 @@
     "        cursor.copy_from(buffer, table, sep=\",\")\n",
     "        conn.commit()\n",
     "    except (Exception, psycopg2.DatabaseError) as error:\n",
-    "        os.remove(tmp_df)\n",
     "        print(\"Error: %s\" % error)\n",
     "        conn.rollback()\n",
     "        cursor.close()\n",


### PR DESCRIPTION
tmp_df is not defined or used in scope of copy_from_stringio, looks like a copy error from the previous copy_from_file function.